### PR TITLE
provide warnings about unsupported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 node_js:
   - '4'
   - '6'
+  - '7'
 env:
   global:
     - CXX=g++-4.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 ## Unreleased
 
 
+### Added
+
+-   use [nodejs-support-dates](https://github.com/jokeyrhyme/nodejs-support-dates.js) to provide warnings about unsupported versions
+
+
 ## 1.0.1 - 2016-10-25
 
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,6 @@ updateNodejsNotifier({
 ```
 
 
-## Roadmap
-
--   [ ] finish "notSupported" behaviour
-
-
 ## See Also
 
 -   [boxen-notify](https://github.com/jokeyrhyme/boxen-notify.js)
@@ -53,3 +48,5 @@ updateNodejsNotifier({
 -   [package-engines-notifier](https://github.com/jokeyrhyme/package-engines-notifier.js)
 
 -   [update-notifier](https://github.com/yeoman/update-notifier)
+
+-   [nodejs-support-dates](https://github.com/jokeyrhyme/nodejs-support-dates.js)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,11 +3,11 @@ environment:
   matrix:
     - nodejs_version: '4'
     - nodejs_version: '6'
+    - nodejs_version: '7'
 install:
   - ps: 'Install-Product node $env:nodejs_version x64'
   - npm install
 test_script:
   - node --version
   - npm --version
-  - npm cache clean
   - npm test

--- a/lib/alerts.js
+++ b/lib/alerts.js
@@ -52,6 +52,13 @@ ALERTS[NOT_SUPPORTED] = {
     list /* : NodejsVersion[] */,
     currentVersion /* : string */
   ) /* : boolean */ => {
+    const datesFromVersion = require('nodejs-support-dates').datesFromVersion
+
+    const end = datesFromVersion(currentVersion).end
+    if (end < Date.now()) {
+      return true
+    }
+
     return false
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "chalk": "^1.1.3",
     "hsipe": "^2.0.0",
     "node-fetch": "^1.6.3",
+    "nodejs-support-dates": "^1.0.2",
     "semver": "^5.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
     "ava": "^0.16.0",
     "eslint": "^3.8.1",
     "eslint-config-standard": "^6.2.0",
-    "eslint-plugin-node": "^2.1.3",
+    "eslint-plugin-node": "^3.0.0",
     "eslint-plugin-promise": "^3.3.0",
     "eslint-plugin-standard": "^2.0.1",
     "fixpack": "^2.3.1",
-    "flow-bin": "^0.33.0",
+    "flow-bin": "^0.34.0",
     "nyc": "^8.3.2"
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ava": "nyc ava",
     "eslint": "eslint --fix --cache .",
     "fixpack": "fixpack",
-    "flow_check": "flow check || exit 0",
+    "flow_check": "flow check",
     "nyc": "nyc check-coverage",
     "posttest": "npm run eslint && npm run flow_check && npm run fixpack",
     "test": "npm run ava && npm run nyc"

--- a/test/alerts.js
+++ b/test/alerts.js
@@ -61,6 +61,22 @@ test('matchAlerts() returns 1st matching alert', (t) => {
   }, list, 'v1.2.3'), expected)
 })
 
+test('notSupported test()', (t) => {
+  const ltsFromDate = require('nodejs-support-dates').ltsFromDate
+
+  const ltsMajor = ltsFromDate(new Date())
+  t.is(
+    lib.ALERTS['notSupported'].test({}, [], 'v5.0.0'),
+    true,
+    'v5.x is not supported now, alert!'
+  )
+  t.is(
+    lib.ALERTS['notSupported'].test({}, [], `v${ltsMajor}.0.0`),
+    false,
+    'LTS versions are supported, no alert'
+  )
+})
+
 test('stableMajor test()', (t) => {
   const list = [
     { version: 'v3.4.5', date: '', files: [], modules: '', lts: false },


### PR DESCRIPTION
### Added

-   use [nodejs-support-dates](https://github.com/jokeyrhyme/nodejs-support-dates.js) to provide warnings about unsupported versions
