### PR TITLE
fix "update" message for unstable Node.js versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@
 
 ### Changed
 
--   if caller passes "versions" in, don't fetch versions (better for testing)
+-   if caller passes `versions` in, don't fetch versions (better for testing)
 
--   allow caller to pass in "notify" function (better for testing)
+-   allow caller to pass in `notify()` function (better for testing)
+
+
+### Fixed
+
+-   "update" message for unstable Node.js versions (#7)
 
 
 ## 1.1.0 - 2016-11-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 ## Unreleased
 
 
+### Changed
+
+-   if caller passes "versions" in, don't fetch versions (better for testing)
+
+
 ## 1.1.0 - 2016-11-01
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 -   if caller passes "versions" in, don't fetch versions (better for testing)
 
+-   allow caller to pass in "notify" function (better for testing)
+
 
 ## 1.1.0 - 2016-11-01
 

--- a/index.js
+++ b/index.js
@@ -40,17 +40,21 @@ const defaults = {
 function updateNodejsNotifier (
   options /* : ?UpdateNodejsNotifierOptions */
 ) /* : boolean */ {
-  putInOven({
-    bakePath: path.join(__dirname, 'lib', 'bake.js'),
-    cakeName,
-    interval: 5 * ONE_DAY
-  })
-
   options = Object.assign({}, defaults, options)
 
-  // try to continue on, in case we already started baking last time
-  const cake = getCake({ cakeName })
-  const nodejsVersions = options.versions || cake.versions
+  const nodejsVersions = options.versions || (() => {
+    putInOven({
+      bakePath: path.join(__dirname, 'lib', 'bake.js'),
+      cakeName,
+      interval: 5 * ONE_DAY
+    })
+
+    // try to continue on, in case we already started baking last time
+    const cake = getCake({ cakeName })
+
+    return cake.versions
+  })()
+
   const current = options.current || process.version
 
   if (nodejsVersions) {

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ export type UpdateNodejsNotifierOptions = {
   stablePatch?: boolean,
 
   current?: string,
+  notify?: ({ message: string }) => void,
   versions?: NodejsVersion[]
 }
 */
@@ -76,7 +77,11 @@ function updateNodejsNotifier (
     // TODO: figure out better update instructions
     // ' \nRun ' + chalk.cyan('custom update command') + ' to update'
 
-    require('boxen-notify').notify({ message })
+    if (typeof options.notify === 'function') {
+      options.notify({ message })
+    } else {
+      require('boxen-notify').notify({ message })
+    }
     return true
   }
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const path = require('path')
 
 const getCake = require('hsipe').getCake
 const putInOven = require('hsipe').putInOven
+const semver = require('semver')
 
 const NODEJS_URL = require('./lib/bake.js').NODEJS_URL
 
@@ -67,7 +68,10 @@ function updateNodejsNotifier (
 
     const chalk = require('chalk') // slow, so do this _after_ check
 
-    const latest = versions.latestStableVersion(nodejsVersions)
+    let latest = versions.latestStableVersion(nodejsVersions)
+    if (semver.gt(current, latest)) {
+      latest = versions.latestVersion(nodejsVersions)
+    }
     const message = chalk.blue('Node.js') +
       chalk.reset(' update available ') +
       chalk.dim(current) + chalk.reset(' → ') +

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "eslint-plugin-promise": "^3.3.0",
     "eslint-plugin-standard": "^2.0.1",
     "fixpack": "^2.3.1",
-    "flow-bin": "^0.37.0",
+    "flow-bin": "^0.38.0",
     "nyc": "^10.0.0"
   },
   "directories": {

--- a/test/index.js
+++ b/test/index.js
@@ -12,13 +12,16 @@ test('exports an "updateNodejsNotifier" function', (t) => {
   t.is(typeof lib.updateNodejsNotifier, 'function')
 })
 
+// assumes current Node.js version is >=4
 test('updateNodejsNotifier({ versions }), no matching alert', (t) => {
   const versions = [
     { version: 'v3.4.5', date: '', files: [], modules: '', lts: false },
     { version: 'v2.3.4', date: '', files: [], modules: '', lts: false },
     { version: 'v1.2.3', date: '', files: [], modules: '', lts: false }
   ]
-  t.is(lib.updateNodejsNotifier({ versions }), false)
+  const notify = () => { notify.called = true }
+  t.is(lib.updateNodejsNotifier({ notify, versions }), false)
+  t.falsy(notify.called)
 })
 
 test('updateNodejsNotifier({ versions }), matching alert', (t) => {
@@ -27,9 +30,16 @@ test('updateNodejsNotifier({ versions }), matching alert', (t) => {
     { version: 'v2.3.4', date: '', files: [], modules: '', lts: false },
     { version: 'v1.2.3', date: '', files: [], modules: '', lts: false }
   ]
+  const notify = (options) => {
+    const message = options.message || ''
+    t.truthy(message)
+    notify.called = true
+  }
   t.is(lib.updateNodejsNotifier({
     current: 'v1.2.3',
+    notify,
     stableMajor: true,
     versions
   }), true)
+  t.truthy(notify.called)
 })

--- a/test/index.js
+++ b/test/index.js
@@ -13,7 +13,7 @@ test('exports an "updateNodejsNotifier" function', (t) => {
 })
 
 // assumes current Node.js version is >=4
-test('updateNodejsNotifier({ versions }), no matching alert', (t) => {
+test('updateNodejsNotifier(), no matching alert', (t) => {
   const versions = [
     { version: 'v3.4.5', date: '', files: [], modules: '', lts: false },
     { version: 'v2.3.4', date: '', files: [], modules: '', lts: false },
@@ -24,7 +24,7 @@ test('updateNodejsNotifier({ versions }), no matching alert', (t) => {
   t.falsy(notify.called)
 })
 
-test('updateNodejsNotifier({ versions }), matching alert', (t) => {
+test('updateNodejsNotifier(), matching alert', (t) => {
   const versions = [
     { version: 'v3.4.5', date: '', files: [], modules: '', lts: false },
     { version: 'v2.3.4', date: '', files: [], modules: '', lts: false },
@@ -39,6 +39,30 @@ test('updateNodejsNotifier({ versions }), matching alert', (t) => {
     current: 'v1.2.3',
     notify,
     stableMajor: true,
+    versions
+  }), true)
+  t.truthy(notify.called)
+})
+
+test('updateNodejsNotifier(), old unstable major version', (t) => {
+  const TODAY = (new Date()).toISOString()
+  const THREE_DAYS = 3 * 24 * 60 * 60 * 1000
+  const OLD_DAY = (new Date(Date.now() - THREE_DAYS)).toISOString()
+  const versions = [
+    { version: 'v7.1.0', date: TODAY, files: [], modules: '', lts: false },
+    { version: 'v6.9.0', date: TODAY, files: [], modules: '', lts: false },
+    { version: 'v7.0.0', date: OLD_DAY, files: [], modules: '', lts: false }
+  ]
+  const notify = (options) => {
+    const message = options.message || ''
+    t.is(message, `Node.js update available v7.0.0 → v7.1.0
+v7.0.0 is more than 1 days old`)
+    notify.called = true
+  }
+  t.is(lib.updateNodejsNotifier({
+    current: 'v7.0.0',
+    daysOld: 1,
+    notify,
     versions
   }), true)
   t.truthy(notify.called)


### PR DESCRIPTION
### Changed

-   if caller passes `versions` in, don't fetch versions (better for testing)

-   allow caller to pass in `notify()` function (better for testing)


### Fixed

-   "update" message for unstable Node.js versions (#7)